### PR TITLE
Add `providers` output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         if: steps.pre.outcome != 'failure'
         run: exit 1
       - name: bendrucker/terraform-configuration-aliases-action
+        id: aliases
         uses: ./
         with:
           path: example/
@@ -30,4 +31,4 @@ jobs:
         working-directory: example/
       - name: Assert "providers" output is set
         run: |
-          [[ ${{ steps.post.outputs.providers }} == '{"provider":{"null":[{"alias":"alt"}]}}'
+          [[ ${{ steps.aliases.outputs.providers }} == '{"provider":{"null":[{"alias":"alt"}]}}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
         working-directory: example/
       - name: Assert "providers" output is set
         run: |
-          [[ '${{ steps.aliases.outputs.providers }}' == '{"provider":{"null":[{"alias":"alt"}]}}'
+          [[ '${{ steps.aliases.outputs.providers }}' == '{"provider":{"null":[{"alias":"alt"}]}}' ]]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,6 @@ jobs:
       - id: post
         run: terraform validate
         working-directory: example/
+      - name: Assert "providers" output is set
+        run: |
+          [[ ${{ steps.post.outputs.providers }} == '{"provider":{"null":[{"alias":"alt"}]}}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
         working-directory: example/
       - name: Assert "providers" output is set
         run: |
-          [[ ${{ steps.aliases.outputs.providers }} == '{"provider":{"null":[{"alias":"alt"}]}}'
+          [[ '${{ steps.aliases.outputs.providers }}' == '{"provider":{"null":[{"alias":"alt"}]}}'

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ steps:
 | Name | Description            | Default |
 |------|------------------------|---------|
 | path | The path to the module | `''`    |
+
+### Outputs
+
+| Name      | Description                                           |
+|-----------|-------------------------------------------------------|
+| providers | The generated provider configuration as a JSON string |

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: The path to the Terraform module
     required: false
     default: './'
+outputs:
+  providers:
+    description: The generated provider configuration as a JSON string
+    value: ${{ steps.aliases.outputs.providers }}
 runs:
   using: composite
   steps:
@@ -20,10 +24,11 @@ runs:
         GO111MODULE: 'on'
     - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       shell: bash
-    - run: |
+    - id: aliases
+      run: |
         echo "Generating providers for configuration_aliases in Terraform module: ${{ inputs.path }}"
         ${{ github.action_path }}/providers.sh | tee aliased-providers.tf.json
-        providers=$(jq -r -c < aliased-providers.tf.json)
-        echo "::set-output name=providers::foo"
+        providers=$(jq -c < aliased-providers.tf.json)
+        echo "::set-output name=providers::${providers}"
       shell: bash
       working-directory: ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
     - run: |
         echo "Generating providers for configuration_aliases in Terraform module: ${{ inputs.path }}"
         ${{ github.action_path }}/providers.sh | tee aliased-providers.tf.json
-        providers=$(jq -c < aliased-providers.tf.json)
+        providers=$(jq -r -c < aliased-providers.tf.json)
         echo "::set-output name=providers::${providers}"
       shell: bash
       working-directory: ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,6 @@ runs:
         echo "Generating providers for configuration_aliases in Terraform module: ${{ inputs.path }}"
         ${{ github.action_path }}/providers.sh | tee aliased-providers.tf.json
         providers=$(jq -r -c < aliased-providers.tf.json)
-        echo "::set-output name=providers::${providers}"
+        echo "::set-output name=providers::foo"
       shell: bash
       working-directory: ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,7 @@ runs:
     - run: |
         echo "Generating providers for configuration_aliases in Terraform module: ${{ inputs.path }}"
         ${{ github.action_path }}/providers.sh | tee aliased-providers.tf.json
+        providers=$(jq -c < aliased-providers.tf.json)
+        echo "::set-output name=providers::${providers}"
       shell: bash
       working-directory: ${{ inputs.path }}


### PR DESCRIPTION
Exposes the generated providers as a JSON string in case the user wants to do something with the result