### PR TITLE
fix!: use go install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
       - uses: hashicorp/setup-terraform@v2
       - run: terraform init
         working-directory: example/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This action inspects a Terraform module, finds all configuration aliases, and wr
 
 ```yaml
 steps:
+  - uses: actions/setup-go@v3
+    with:
+      go-version: '1.18'
   - uses: bendrucker/terraform-configuration-aliases-action@v1
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -16,8 +16,8 @@ runs:
   using: composite
   steps:
     - run: |
-        echo "::group::go get github.com/hashicorp/terraform-config-inspect"
-        go get github.com/hashicorp/terraform-config-inspect
+        echo "::group::go install github.com/hashicorp/terraform-config-inspect@latest"
+        go install github.com/hashicorp/terraform-config-inspect@latest
         echo "::endgroup::"
       shell: bash
       env:


### PR DESCRIPTION
github.com/hashicorp/terraform-config-inspect is now requiring go 1.18 which no longer supports go get

Closes #7