### PR TITLE
Replace `go get` with `go install`, pin version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
         echo "::endgroup::"
       shell: bash
       env:
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ inputs.terraform-config-inspect-version }}
     - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       shell: bash
     - id: aliases

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
     description: The path to the Terraform module
     required: false
     default: './'
+  terraform-config-inspect-version: 81db043ad408976450c4af995dbe69ae70b26c82
 outputs:
   providers:
     description: The generated provider configuration as a JSON string
@@ -16,12 +17,13 @@ runs:
   using: composite
   steps:
     - run: |
-        echo "::group::go get github.com/hashicorp/terraform-config-inspect"
-        go get github.com/hashicorp/terraform-config-inspect
+        echo "::group::go install github.com/hashicorp/terraform-config-inspect"
+        echo "version: $VERSION"
+        go install github.com/hashicorp/terraform-config-inspect@$VERSION
         echo "::endgroup::"
       shell: bash
       env:
-        GO111MODULE: 'on'
+        VERSION: ${{ inputs.version }}
     - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       shell: bash
     - id: aliases

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,10 @@ inputs:
     description: The path to the Terraform module
     required: false
     default: './'
-  terraform-config-inspect-version: 81db043ad408976450c4af995dbe69ae70b26c82
+  terraform-config-inspect-version:
+    description: The version of http://github.com/hashicorp/terraform-config-inspect to install
+    required: false
+    default: 81db043ad408976450c4af995dbe69ae70b26c82
 outputs:
   providers:
     description: The generated provider configuration as a JSON string

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   terraform-config-inspect-version:
     description: The version of http://github.com/hashicorp/terraform-config-inspect to install
     required: false
-    default: 81db043ad408976450c4af995dbe69ae70b26c82
+    default: 90acf1ca460f724f61d41ab67c8752e74a792e96
 outputs:
   providers:
     description: The generated provider configuration as a JSON string

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,13 @@ runs:
     - run: |
         echo "::group::go install github.com/hashicorp/terraform-config-inspect"
         echo "version: $VERSION"
-        go install github.com/hashicorp/terraform-config-inspect@$VERSION
+
+        cd "$(mktemp -d)"
+        go mod init m
+
+        go get github.com/hashicorp/terraform-config-inspect@$VERSION
+        go install github.com/hashicorp/terraform-config-inspect
+
         echo "::endgroup::"
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -22,13 +22,7 @@ runs:
     - run: |
         echo "::group::go install github.com/hashicorp/terraform-config-inspect"
         echo "version: $VERSION"
-
-        cd "$(mktemp -d)"
-        go mod init m
-
-        go get github.com/hashicorp/terraform-config-inspect@$VERSION
-        go install github.com/hashicorp/terraform-config-inspect
-
+        go install github.com/hashicorp/terraform-config-inspect@$VERSION
         echo "::endgroup::"
       shell: bash
       env:


### PR DESCRIPTION
Uses `go install` to install https://github.com/hashicorp/terraform-config-inspect. Pins to the last meaningful revision before https://github.com/hashicorp/terraform-config-inspect/commit/81db043ad408976450c4af995dbe69ae70b26c82, which requires `go@1.18`. The changes introduced there are only relevant to the Go API and not CLI usage. Restoring `latest` as the version target will be a breaking change, as it will require `go@1.18`. 

Closes #7, Closes #6