### PR TITLE
fix: remove deprecated set-output command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,6 @@ runs:
         echo "Generating providers for configuration_aliases in Terraform module: ${{ inputs.path }}"
         ${{ github.action_path }}/providers.sh | tee aliased-providers.tf.json
         providers=$(jq -c < aliased-providers.tf.json)
-        echo "::set-output name=providers::${providers}"
+        echo "providers=${providers}" >> $GITHUB_OUTPUT
       shell: bash
       working-directory: ${{ inputs.path }}


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands